### PR TITLE
Allow parallel support in python 3

### DIFF
--- a/ebaysdk/parallel.py
+++ b/ebaysdk/parallel.py
@@ -12,9 +12,6 @@ from ebaysdk.exception import ConnectionError
 import grequests
 # pylint: enable=import-error
 
-if sys.version_info[0] >= 3:
-    raise ImportError('grequests does not work with python3+')
-
 
 class Parallel(object):
     """


### PR DESCRIPTION
I tested this by commenting those lines out in the site-packages, (on Anaconda on Windows). Everything seems to work fine; if you import parallel after importing other ebaysdk packages, though, you get a "monkey patch" warning message. Regardless of whether you import it before or after, basic things seem to work fine with Parallel on python 3; I haven't tested everything though.

P.S. I've never submitted a "real" pull request before, so it is probable I've done something wrong.